### PR TITLE
do not advertise firehose finalized block when syncing behind beacon finalized block

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -143,7 +143,15 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 			td = new(big.Int).Add(difficulty, ptd)
 		}
 
-		firehoseContext.EndBlock(block, p.bc.CurrentFinalizedBlock(), td)
+		finalizedBlock := p.bc.CurrentFinalizedBlock()
+
+		if finalizedBlock != nil && firehose.SyncingBehindFinalized() {
+			// if beaconFinalizedBlockNum is in the future, the 'finalizedBlock' will not progress until we reach it.
+			// we don't want to advertise a super old finalizedBlock when reprocessing.
+			finalizedBlock = nil
+		}
+
+		firehoseContext.EndBlock(block, finalizedBlock, td)
 	}
 
 	return receipts, allLogs, *usedGas, nil

--- a/firehose/types.go
+++ b/firehose/types.go
@@ -2,11 +2,26 @@ package firehose
 
 import (
 	"math/big"
+	"sync/atomic"
 
 	"github.com/golang-collections/collections/stack"
 )
 
 var EmptyValue = new(big.Int)
+
+var behindFinalized int32
+
+func SyncingBehindFinalized() bool {
+	return atomic.LoadInt32(&behindFinalized) != 0
+}
+
+func SetSyncingBehindFinalized(behind bool) {
+	if behind {
+		atomic.StoreInt32(&behindFinalized, 1)
+	} else {
+		atomic.StoreInt32(&behindFinalized, 0)
+	}
+}
 
 type logItem = map[string]interface{}
 


### PR DESCRIPTION
When local DB is synced up to block 1000 but beacon chain sends us a request to set our head block to 20,000 with a last FinalizedBlock hash that is not yet in our local DB, the firehose plugin will output the previously found FinalizedBlock until we actually get to that block 20,000. When reprocessing a chain to produce firehose blocks, this is an issue, the FinalizedBlockNum (LIB, from LastIrreversibleBlock ...) must progress !
By *NOT* outputing any FinalizedBlock in the firehose output, we allow the Reader component of the firehose to take other business decision (ex: LIBnum = blockNum - 200) 