### PR TITLE
FIX: Added receipt in processor.go/ApplyMessage

### DIFF
--- a/consensus/bor/contract/client.go
+++ b/consensus/bor/contract/client.go
@@ -93,7 +93,7 @@ func (gc *GenesisContractsClient) CommitState(
 
 	log.Info("→ committing new state", "eventRecord", event.ID)
 
-	gasUsed, err := statefull.ApplyMessage(context.Background(), msg, state, header, gc.chainConfig, chCtx, 0, tracer)
+	gasUsed, err := statefull.ApplyMessage(context.Background(), msg, state, header, gc.chainConfig, chCtx, tracer)
 
 	// Logging event log with time and individual gasUsed
 	log.Info("→ committed new state", "eventRecord", event.String(gasUsed))

--- a/consensus/bor/heimdall/span/spanner.go
+++ b/consensus/bor/heimdall/span/spanner.go
@@ -336,7 +336,7 @@ func (c *ChainSpanner) CommitSpan(ctx context.Context, heimdallSpan HeimdallSpan
 	msg := statefull.GetSystemMessage(c.validatorContractAddress, data)
 
 	// apply message
-	_, err = statefull.ApplyMessage(ctx, msg, state, header, c.chainConfig, chainContext, 0, tracer)
+	_, err = statefull.ApplyMessage(ctx, msg, state, header, c.chainConfig, chainContext, tracer)
 
 	return err
 }

--- a/consensus/bor/statefull/processor.go
+++ b/consensus/bor/statefull/processor.go
@@ -71,7 +71,6 @@ func ApplyMessage(
 	header *types.Header,
 	chainConfig *params.ChainConfig,
 	chainContext core.ChainContext,
-	spanID int64,
 	tracer *tracing.Hooks,
 ) (uint64, error) {
 

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -711,7 +711,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			if *config.BorTraceEnabled {
 				callmsg := prepareCallMessage(*msg)
 				statedb.SetTxContext(stateSyncHash, i)
-				if _, err := statefull.ApplyMessage(ctx, callmsg, statedb, block.Header(), api.backend.ChainConfig(), api.chainContext(ctx), 0, nil); err != nil {
+				if _, err := statefull.ApplyMessage(ctx, callmsg, statedb, block.Header(), api.backend.ChainConfig(), api.chainContext(ctx), nil); err != nil {
 					log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", stateSyncHash, "err", err)
 					// We intentionally don't return the error here: if we do, then the RPC server will not
 					// return the roots. Most likely, the caller already knows that a certain transaction fails to


### PR DESCRIPTION
Issue: The receipt was not displaying when running the tests in 3.0 with applyBackwardCompatibility
Fix: Added the receipt in ApplyMessage