### PR TITLE
firehose: synthesize root call for transactions that skip EVM execution

### DIFF
--- a/eth/tracers/firehose.go
+++ b/eth/tracers/firehose.go
@@ -509,6 +509,33 @@ func (f *Firehose) OnTxEnd(receipt *types.Receipt, err error) {
 		case types.ArbitrumDepositTxType, types.ArbitrumSubmitRetryableTxType, types.ArbitrumInternalTxType:
 			firehoseDebug("closing simulated root call to arbitrum (tx_type=%d)", receipt.Type)
 			f.callEnd("root", nil, receipt.GasUsed, err, err != nil)
+
+		default:
+			// Arbitrum's `TxProcessor.RevertedTxHook` can skip EVM execution entirely (on-chain
+			// filtered transactions and hardcoded `core.RevertedTxGasUsed` hashes) leaving a receipt
+			// but no recorded call, synthesize a root call like the Arbitrum tx types above.
+			if len(f.transaction.Calls) == 0 && !f.callStack.HasActiveCall() {
+				firehoseInfo("synthesizing root call for transaction executed without any EVM call (tx_type=%d, receipt_status=%d)", receipt.Type, receipt.Status)
+
+				callErr := err
+				if callErr == nil && receipt.Status == types.ReceiptStatusFailed {
+					callErr = errors.New("transaction skipped EVM execution (Arbitrum RevertedTxHook, filtered or hardcoded reverted transaction)")
+				}
+
+				var value *big.Int
+				if f.transaction.Value != nil {
+					value = new(big.Int).SetBytes(f.transaction.Value.Bytes)
+				}
+
+				f.callStart("root", pbeth.CallType_CALL,
+					common.BytesToAddress(f.transaction.From),
+					common.BytesToAddress(f.transaction.To),
+					f.transaction.Input,
+					f.transaction.GasLimit,
+					value,
+				)
+				f.callEnd("root", nil, receipt.GasUsed, callErr, receipt.Status == types.ReceiptStatusFailed)
+			}
 		}
 
 		f.block.TransactionTraces = append(f.block.TransactionTraces, f.completeTransaction(receipt))

--- a/eth/tracers/firehose_test.go
+++ b/eth/tracers/firehose_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 	pbeth "github.com/streamingfast/firehose-ethereum/types/pb/sf/ethereum/type/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -451,6 +452,94 @@ func blockEvent(height uint64) tracing.BlockEvent {
 			Number: big.NewInt(int64(height)),
 		}, nil, nil, nil),
 	}
+}
+
+// TestFirehose_TxSkippedByRevertedTxHookSynthesizesRootCall covers Arbitrum transactions
+// skipped by `TxProcessor.RevertedTxHook`: the EVM never runs so no call is ever recorded,
+// but the transaction still gets a failed receipt consuming all gas. `completeTransaction`
+// used to panic on the missing root call (Robinhood Chain 4663, block 604227).
+func TestFirehose_TxSkippedByRevertedTxHookSynthesizesRootCall(t *testing.T) {
+	f := NewFirehose(&FirehoseConfig{
+		private: &privateFirehoseConfig{FlushToTestBuffer: true},
+	})
+
+	f.OnBlockchainInit(params.TestChainConfig)
+	f.OnBlockStart(blockEvent(604227))
+
+	tx := types.NewTx(&types.LegacyTx{
+		Nonce:    1,
+		GasPrice: big.NewInt(120000000),
+		Gas:      100000,
+		To:       &to,
+		Value:    big.NewInt(999),
+		Data:     nil,
+	})
+
+	f.OnTxStart(&tracing.VMContext{}, tx, from)
+
+	receipt := &types.Receipt{
+		Type:              types.LegacyTxType,
+		Status:            types.ReceiptStatusFailed,
+		GasUsed:           tx.Gas(),
+		CumulativeGasUsed: tx.Gas(),
+		TransactionIndex:  1,
+	}
+
+	require.NotPanics(t, func() { f.OnTxEnd(receipt, nil) })
+
+	require.Len(t, f.block.TransactionTraces, 1)
+	trace := f.block.TransactionTraces[0]
+
+	require.Len(t, trace.Calls, 1)
+	rootCall := trace.Calls[0]
+
+	assert.Equal(t, pbeth.CallType_CALL, rootCall.CallType)
+	assert.Equal(t, from.Bytes(), rootCall.Caller)
+	assert.Equal(t, to.Bytes(), rootCall.Address)
+	assert.Equal(t, big.NewInt(999).Bytes(), rootCall.Value.Bytes)
+	assert.Equal(t, uint64(100000), rootCall.GasLimit)
+	assert.Equal(t, uint64(100000), rootCall.GasConsumed)
+	assert.True(t, rootCall.StatusFailed, "synthesized root call must be failed since the receipt is failed")
+	assert.True(t, rootCall.StateReverted, "synthesized root call must have its state reverted since it failed")
+	assert.Equal(t, pbeth.TransactionTraceStatus_FAILED, trace.Status)
+
+	// Root call BeginOrdinal is forced to 0 (known Firehose quirk, see `callStart`), the
+	// remaining ordinals must stay monotonic
+	assert.Equal(t, uint64(0), rootCall.BeginOrdinal)
+	assert.Less(t, trace.BeginOrdinal, rootCall.EndOrdinal)
+	assert.Less(t, rootCall.EndOrdinal, trace.EndOrdinal)
+
+	require.NotPanics(t, func() { f.OnBlockEnd(nil) })
+}
+
+// TestFirehose_TxSkippedByRevertedTxHookSuccessfulReceipt covers the same EVM-less shape but
+// with a successful receipt, the synthesized root call must then be successful too.
+func TestFirehose_TxSkippedByRevertedTxHookSuccessfulReceipt(t *testing.T) {
+	f := NewFirehose(&FirehoseConfig{
+		private: &privateFirehoseConfig{FlushToTestBuffer: true},
+	})
+
+	f.OnBlockchainInit(params.TestChainConfig)
+	f.OnBlockStart(blockEvent(604227))
+	f.OnTxStart(&tracing.VMContext{}, txEvent(), from)
+
+	receipt := txReceiptEvent(0)
+	receipt.GasUsed = 21000
+	receipt.CumulativeGasUsed = 21000
+
+	require.NotPanics(t, func() { f.OnTxEnd(receipt, nil) })
+
+	require.Len(t, f.block.TransactionTraces, 1)
+	trace := f.block.TransactionTraces[0]
+
+	require.Len(t, trace.Calls, 1)
+	rootCall := trace.Calls[0]
+
+	assert.False(t, rootCall.StatusFailed)
+	assert.False(t, rootCall.StateReverted)
+	assert.Equal(t, pbeth.TransactionTraceStatus_SUCCEEDED, trace.Status)
+
+	require.NotPanics(t, func() { f.OnBlockEnd(nil) })
 }
 
 func TestMemory_GetPtr(t *testing.T) {


### PR DESCRIPTION
## Problem

Arbitrum's `TxProcessor.RevertedTxHook` can skip EVM execution entirely for ordinary tx types (on-chain filtered transactions and the hardcoded `core.RevertedTxGasUsed` hashes). The tx still gets a receipt (status 0x0, gasUsed == gasLimit, no logs), but `evm.Call` never runs, so `OnCallEnter` never fires and `f.transaction.Calls` is empty when `OnTxEnd` runs:

    rootCall := f.transaction.Calls[0]   // panic: index out of range [0] with length 0  (firehose.go:532)

The panic unwinds through `OnBlockEnd` and kills the `TransactionStreamer` goroutine, zombifying the Firehose reader.

Deterministic repro: Robinhood Chain (chain-id 4663), block 604227, tx `0xd1646236684c83de201978aacaeeefcc8845417f36ca2c45f60b22821a38ff3b`, with `--execution.vmtrace.tracer-name=firehose`.

## Fix

In `OnTxEnd`, when a receipt is present but no call was recorded, synthesize a root call using the same simulated-call pattern already used for the EVM-less Arbitrum tx types: `callStart("root", ...)` from the fields captured in `onTxStart`, closed by `callEnd("root", ...)`. The call is marked failed when the receipt is failed, so state-reverted flags and trace status match chain reality, and ordinals stay monotonic. Chosen over a bare `len()==0` guard because downstream consumers (fireeth console reader, graph-node) expect every trace to have a root call.

Deploying this requires bumping nitro's pinned `go-ethereum` submodule to this branch's head (`e8b75002b`). Fix confirmed with a prebuilt image at `vincenttaglia/nitro:v3.11.1-fh3.0-filteredtx-fix1`.

## Testing

New unit tests drive `OnBlockStart -> OnTxStart -> OnTxEnd` with failed and successful receipts and no `OnCallEnter`/`OnCallExit`: no panic, one synthesized root call, correct status, monotonic ordinals. The failed-receipt test panics at firehose.go:532 without the fix. Full `go test ./eth/tracers/...` passes.

🤖 Scaffold generated by Claude Code, 
👨‍🦱 Edited by me

Let me know if there's anything I can do before upstreaming.